### PR TITLE
Fix release list race

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ You'll need Node.js, a MongoDB server, and a Twitch app (for login) to run the a
   - `SESSION_SECRET` and `SESSION_KEY` should be randomly generated, equivalent to a password
   - `JWT_SECRET` should be randomly generated, equivalent to a password
 - Run `index.js` (optional: run under something like `nodemon` to restart when contents change)
+- When changing the mod itself, run `DEV=true ./bundle` in the project root to create a development release for download from the web ui
 
 # Developing the mod
 The mod files themselves are kept in this repository in the [mod](mod) folder. Start with a customized zip (your user token is stored in [mod/token.lua](mod/token.lua))

--- a/bundle
+++ b/bundle
@@ -4,6 +4,8 @@ set -e
 
 name="streamer_wands"
 version="$(jq -r '.version' package.json)"
-sha="$(git rev-parse --short HEAD)"
+if [ -n "$DEV" ]; then
+  version="$version+$(git rev-parse --short HEAD)"
+fi
 
-git -c core.autocrlf=false archive --prefix="$name/" -o "releases/$name--$version+$sha".zip HEAD:mod
+git -c core.autocrlf=false archive --prefix="$name/" -o "releases/$name--$version".zip HEAD:mod

--- a/routes/index.js
+++ b/routes/index.js
@@ -14,7 +14,7 @@ let lastUpdated = null
 let releaseList = []
 const releaseDir = PATH.resolve(__dirname, '..', 'releases')
 
-const updateFrequency = 60 * 1000 // 60 seconds
+const updateFrequency = 10 * 60 * 1000 // 10 minutes
 
 const getZipStream = async (relPath, jwt) => {
     const path = PATH.resolve(releaseDir, relPath)

--- a/routes/index.js
+++ b/routes/index.js
@@ -32,24 +32,27 @@ const getZipStream = async (relPath, jwt) => {
     return zip.generateNodeStream()
 }
 
-const getReleases = async () => {
+const getReleases = () => {
     const now = Date.now()
     const timeToNext = lastUpdated + updateFrequency - now
     if (lastUpdated === null || timeToNext < 0) {
         console.log(`updating release list: timeToNext=${timeToNext}`)
-        const paths = await fs.readdir(releaseDir, { withFileTypes: true })
-        const stats = paths
-            .filter((file) => file.isFile() && /\.zip$/.test(file.name))
-            .map(async (file) => {
-                const path = PATH.resolve(releaseDir, file.name)
-                const stat = await fs.stat(path)
-                const relPath = PATH.relative(releaseDir, path)
-                return { mtime: stat.mtime, name: file.name, path: relPath }
-            })
-
-        releaseList = await Promise.all(stats)
-        releaseList.sort((a, b) => b.mtime - a.mtime)
         lastUpdated = now
+        releaseList = new Promise(async (resolve) => {
+            const paths = await fs.readdir(releaseDir, { withFileTypes: true })
+            const stats = paths
+                .filter((file) => file.isFile() && /\.zip$/.test(file.name))
+                .map(async (file) => {
+                    const path = PATH.resolve(releaseDir, file.name)
+                    const stat = await fs.stat(path)
+                    const relPath = PATH.relative(releaseDir, path)
+                    return { mtime: stat.mtime, name: file.name, path: relPath }
+                })
+
+            const withTimes = await Promise.all(stats)
+            withTimes.sort((a, b) => b.mtime - a.mtime)
+            resolve(withTimes)
+        })
     } // test
 
     return releaseList


### PR DESCRIPTION
- Return a promise from `getReleases` and update the timestamp immediately, so that concurrent calls do not cause extra work
- Fix release refresh cache duration
- Make inclusion of the git sha optional