### PR TITLE
Remove margins from only wands

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -463,9 +463,6 @@ a {
 a:visited {
     color: rgb(170, 132, 125);
 }
-p {
-    margin: 0.75rem 0;
-}
 
 .inventory-wrapper {
     margin-top: 0.3rem;


### PR DESCRIPTION
Currently: 
![image](https://github.com/myndzi/streamer-wands-backend/assets/48890028/7e352f5b-7ff2-4315-8616-9602502b8d02)
With the change:
![image](https://github.com/myndzi/streamer-wands-backend/assets/48890028/319a5fd8-22e1-44f0-9b7e-dd91dff5570a)
