### PR TITLE
Add a separate pm2 config for development server

### DIFF
--- a/ecosystem.dev.config.js
+++ b/ecosystem.dev.config.js
@@ -1,0 +1,19 @@
+module.exports = {
+    apps: [
+        {
+            name: 'onlywands-dev',
+            script: 'index.js',
+            autorestart: true,
+            watch: true,
+            watch_delay: 1000,
+            ignore_watch: ['node_modules', 'views', 'public'],
+            max_memory_restart: '1G',
+            env: {
+                NODE_ENV: 'development',
+            },
+            env_production: {
+                NODE_ENV: 'production',
+            },
+        },
+    ],
+}


### PR DESCRIPTION
The "name" property of the config overwrites the production instance when pm2 launches, so we need a different name to run the development instance concurrently with the production instance

(clean this up later)