### PR TITLE
Slipstream stats

### DIFF
--- a/lib/noitastats.js
+++ b/lib/noitastats.js
@@ -29,6 +29,7 @@ const convertNoitaStats = (encrypted) =>
             .toString()
             .match(/<E.+>/g)
             .map((line) => line.match(/"(\w+)" value="(\d+)"/))
+            .map((kv) => `${kv[1]}=${kv[2]}`)
         return `stats = {${vals.join(',')}}`
     })
 

--- a/routes/index.js
+++ b/routes/index.js
@@ -6,7 +6,7 @@ const { convertNoitaStats } = require('../lib/noitastats')
 const storage = multer.memoryStorage({
     limits: {
         parts: 5,
-        fieldSize: 16 * 1024,
+        fieldSize: 128 * 1024,
     },
 })
 const upload = multer({ storage })


### PR DESCRIPTION
increased _stats.salakieli fieldSize from 16 to 128 since mine is 39 KB, and modded could be even larger
Also fixed conversion from decrypted to lua table format