### PR TITLE
Add flex-wrap to switch flexbox container

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -596,6 +596,7 @@ a:visited {
 .switches {
     display: flex;
     flex-direction: row;
+    flex-wrap: wrap;
     width: 100%;
     justify-content: center;
     position: sticky;


### PR DESCRIPTION
Mobile users couldn't access all the switches because they were pushed off the sides of the viewport