### PR TITLE
Hotfix for certain perks not showing up

### DIFF
--- a/mod/files/scripts/utils.lua
+++ b/mod/files/scripts/utils.lua
@@ -62,10 +62,12 @@ function get_perks()
     local perks = {}
     local order = {}
     for _, child in ipairs(childs) do
-        local is_perk = EntityHasTag(child,"perk_entity")
-        local is_essence = EntityHasTag(child,"essence_effect") and not EntityHasTag(child,"essence")
-        local is_pseudo = EntityHasTag(child,"pseudo_perk")
-        if is_perk or is_essence or is_pseudo then
+        local ui_comp = EntityGetFirstComponentIncludingDisabled(child,"UIIconComponent")
+        local perk_comp = (ui_comp ~= nil and string.sub(ComponentGetValue2(ui_comp,"name"),1,5) == "$perk")
+        local perk_tag = EntityHasTag(child,"perk_entity")
+        local essence_tag = EntityHasTag(child,"essence_effect") and not EntityHasTag(child,"essence")
+        local pseudo_tag = EntityHasTag(child,"pseudo_perk")
+        if perk_tag or essence_tag or pseudo_tag or perk_comp then
             local ui_comp = EntityGetFirstComponentIncludingDisabled(child,"UIIconComponent")
             if ui_comp ~= nil then
                 local name = ComponentGetValue2(ui_comp,"name")

--- a/views/wands.pug
+++ b/views/wands.pug
@@ -22,6 +22,7 @@ block content
     const streamerItems = !{JSON.stringify(items)}
     const streamerProgress = !{JSON.stringify(progress)}
     const streamerVersion = !{JSON.stringify(version)}
+    const streamerInfo =  !{JSON.stringify(info)}
   div.wand-display
     div#app
     //- moved to within main.js


### PR DESCRIPTION
Some perks like extra-life (one-off)'s child entity doesn't have the "perk_entity" tag so added an extra perk check for the ui_name having "$perk" in it, now all 106 vanilla perks are tracked.  