### PR TITLE
Fix spell zoom for countable items

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -969,10 +969,6 @@ a:visited {
     image-rendering: pixelated;
 }
 
-.spell-slot p {
-    pointer-events: none;
-}
-
 .item-slot:hover>img {
     transform: scale(120%) translate(-42%, -42%);
 }

--- a/public/style.css
+++ b/public/style.css
@@ -969,6 +969,10 @@ a:visited {
     image-rendering: pixelated;
 }
 
+.spell-slot p {
+    pointer-events: none;
+}
+
 .item-slot:hover>img {
     transform: scale(120%) translate(-42%, -42%);
 }

--- a/public/style.css
+++ b/public/style.css
@@ -1196,7 +1196,7 @@ a:visited {
     transform: scale(120%);
 }
 
-.spellZoom:hover {
+.spell-slot:hover .spellZoom {
     transform: scale(120%);
 }
 


### PR DESCRIPTION
Currently, the zoom effect when hovering over a spell is obstructed by the spell count overlay.

This change disables pointer events for the spell count overlay, allowing the zoom effect to function properly. The change is specifically applied to spells and does not affect items, assuming Noita doesn't allow carrying multiple copies of the same item in the same slot.