### PR TITLE
Wand mod fixes

### DIFF
--- a/mod/files/scripts/utils.lua
+++ b/mod/files/scripts/utils.lua
@@ -193,10 +193,11 @@ function get_wand_stats(id)
 
     local ability_comp = EntityGetFirstComponentIncludingDisabled(id, "AbilityComponent")
     local item_comp = EntityGetFirstComponentIncludingDisabled(id, "ItemComponent")
-    serialized.sprite = ComponentGetValue2(ability_comp, "sprite_file")
+    serialized.sprite = ComponentGetValue2(item_comp, "ui_sprite") or ComponentGetValue2(ability_comp, "sprite_file")
     local use_name = ComponentGetValue2(item_comp, "always_use_item_name_in_ui")
     if use_name then
-        serialized.ui_name = GameTextGetTranslatedOrNot(ComponentGetValue2(ability_comp, "ui_name"))
+        item_name = ComponentGetValue2(item_comp, "item_name") or ComponentGetValue2(ability_comp, "ui_name")
+        serialized.ui_name = GameTextGetTranslatedOrNot(item_name)
     else
         serialized.ui_name = "wand"
     end
@@ -223,23 +224,25 @@ function get_wand_spells(id)
         for _, child in ipairs(childs) do
             local item_comp = EntityGetFirstComponentIncludingDisabled(child, "ItemComponent")
             local item_action_component = EntityGetFirstComponentIncludingDisabled(child, "ItemActionComponent")
-            local is_always_cast = ComponentGetValue2(item_comp, "permanently_attached")
-            local action_id = ComponentGetValue2(item_action_component, "action_id")
-            local slot = ComponentGetValue2(item_comp, "inventory_slot")
-            local charges = ComponentGetValue2(item_comp, "uses_remaining")
-            local empty_slots = slot - last_slot
+            if (item_comp ~= nil) and (item_action_component ~= nil) then
+                local is_always_cast = ComponentGetValue2(item_comp, "permanently_attached")
+                local action_id = ComponentGetValue2(item_action_component, "action_id")
+                local slot = ComponentGetValue2(item_comp, "inventory_slot")
+                local charges = ComponentGetValue2(item_comp, "uses_remaining")
+                local empty_slots = slot - last_slot
 
-            if empty_slots > 0 then
-                for s = 1, empty_slots do
-                    table.insert(deck, "0")
+                if empty_slots > 0 then
+                    for s = 1, empty_slots do
+                        table.insert(deck, "0")
+                        last_slot = last_slot + 1
+                    end
+                end
+                if (is_always_cast) then
+                    table.insert(always_cast, action_id .. "_#" .. charges)
+                else
+                    table.insert(deck, action_id .. "_#" .. charges)
                     last_slot = last_slot + 1
                 end
-            end
-            if (is_always_cast) then
-                table.insert(always_cast, action_id .. "_#" .. charges)
-            else
-                table.insert(deck, action_id .. "_#" .. charges)
-                last_slot = last_slot + 1
             end
         end
     end

--- a/mod/files/scripts/utils.lua
+++ b/mod/files/scripts/utils.lua
@@ -193,7 +193,12 @@ function get_wand_stats(id)
 
     local ability_comp = EntityGetFirstComponentIncludingDisabled(id, "AbilityComponent")
     local item_comp = EntityGetFirstComponentIncludingDisabled(id, "ItemComponent")
-    serialized.sprite = ComponentGetValue2(item_comp, "ui_sprite") or ComponentGetValue2(ability_comp, "sprite_file")
+    local sprite = ComponentGetValue2(item_comp, "ui_sprite")
+    if string.len(sprite) > 0 then
+        serialized.sprite = sprite
+    else
+        serialized.sprite = ComponentGetValue2(ability_comp, "sprite_file")
+    end
     local use_name = ComponentGetValue2(item_comp, "always_use_item_name_in_ui")
     if use_name then
         item_name = ComponentGetValue2(item_comp, "item_name") or ComponentGetValue2(ability_comp, "ui_name")

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "streamer_wands",
-    "version": "1.2.8",
-    "modVersion": "1.2.7",
+    "version": "1.2.9",
+    "modVersion": "1.2.8",
     "description": "",
     "main": "index.js",
     "scripts": {

--- a/public/main.js
+++ b/public/main.js
@@ -1592,7 +1592,7 @@ const containerComp = Vue.component('wands-container', {
                     className: 'beta-content',
                 },
                 apothContent: {
-                    state: HOP(streamerRunInfo, "mods") && HOP(streamerRunInfo.mods, "apotheosis"),
+                    state: HOP(streamerRunInfo, "mods") && HOP(streamerRunInfo.mods.map((mod) => mod.toLowerCase()), "apotheosis"),
                     label: 'Show Apotheosis Content',
                     className: 'apoth-content',
                 },

--- a/public/main.js
+++ b/public/main.js
@@ -1592,7 +1592,7 @@ const containerComp = Vue.component('wands-container', {
                     className: 'beta-content',
                 },
                 apothContent: {
-                    state: streamerRunInfo.mods.includes("apotheosis") || streamerRunInfo.mods.includes("Apotheosis"),
+                    state: streamerRunInfo.mods.some(mod => /apotheosis/i.test(mod)),
                     label: 'Show Apotheosis Content',
                     className: 'apoth-content',
                 },

--- a/public/main.js
+++ b/public/main.js
@@ -1592,7 +1592,7 @@ const containerComp = Vue.component('wands-container', {
                     className: 'beta-content',
                 },
                 apothContent: {
-                    state: HOP(streamerRunInfo, "mods") && HOP(streamerRunInfo.mods.map((mod) => mod.toLowerCase()), "apotheosis"),
+                    state: streamerRunInfo.mods.includes("apotheosis") || streamerRunInfo.mods.includes("Apotheosis"),
                     label: 'Show Apotheosis Content',
                     className: 'apoth-content',
                 },


### PR DESCRIPTION
# JS Onlywands.com Fixes (1.2.8->1.2.9):
- Fixed "Show Apotheosis Content" not auto enabling when streamer has apotheosis mod present
# Noita LUA Mod Fixes (1.2.7->1.2.8):
- Fixed Varpuluuta (aka Broom Wand) crashing the mod
    - the mod would confuse this wand's two entities for broom/cleanup functionality as spells, and try to gather data as though they were spells, when they are in fact not
- Added checks to wand name and wand sprite so they default to ItemComponent and only fallback to AbilityComponent
    - This seems to have fixed things like Wand of Multitudes being called Scattershot Wand (the name from AbilityComponent)
    - Also fixed sprites such as the Broom wand having a random wand sprite for its size instead of its correct plant_02 broom sprite
